### PR TITLE
add lablgtk3-sourceview3 dependency for coqide

### DIFF
--- a/sci-mathematics/coq/coq-8.10_beta2.ebuild
+++ b/sci-mathematics/coq/coq-8.10_beta2.ebuild
@@ -20,7 +20,10 @@ IUSE="gtk debug +ocamlopt doc"
 RDEPEND="
 	>=dev-lang/ocaml-3.11.2:=[ocamlopt?]
 	>=dev-ml/camlp5-6.02.3:=[ocamlopt?]
-	gtk? ( dev-ml/lablgtk3:= )"
+	gtk? (
+		dev-ml/lablgtk3:=
+		dev-ml/lablgtk3-sourceview3:=
+		)"
 DEPEND="${RDEPEND}
 	dev-ml/findlib
 	doc? (


### PR DESCRIPTION
Enabling USE `gtk` fails the compilation when `dev-ml/lablgtk3-sourceview3` is not emerged. Adding the dependency solves the issue. 