### PR TITLE
add missing deps for dev-ml/cairo2

### DIFF
--- a/dev-ml/cairo2/cairo2-0.6.1.ebuild
+++ b/dev-ml/cairo2/cairo2-0.6.1.ebuild
@@ -16,6 +16,7 @@ IUSE=""
 
 DEPEND="
 	x11-libs/cairo:=
+	dev-ml/dune-configurator:=
 "
 RDEPEND="${DEPEND}
 	!dev-ml/ocaml-cairo


### PR DESCRIPTION
The installation of `dev-ml/cairo2` failed with the following message:
```
>>> Emerging (1 of 1) dev-ml/cairo2-0.6.1::ml-overlay
 * cairo2-0.6.1.tbz SHA256 SHA512 WHIRLPOOL size ;-) ...                                [ ok ]
>>> Unpacking source...
>>> Unpacking cairo2-0.6.1.tbz to /var/tmp/portage/dev-ml/cairo2-0.6.1/work
>>> Source unpacked in /var/tmp/portage/dev-ml/cairo2-0.6.1/work
>>> Preparing source in /var/tmp/portage/dev-ml/cairo2-0.6.1/work/cairo2-0.6.1 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-ml/cairo2-0.6.1/work/cairo2-0.6.1 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-ml/cairo2-0.6.1/work/cairo2-0.6.1 ...
File "config/dune", line 5, characters 12-29:
5 |  (libraries dune.configurator str))
                ^^^^^^^^^^^^^^^^^
Error: Library "dune.configurator" not found.
Hint: try: dune external-lib-deps --missing -p cairo2 -j 4 @install
 * ERROR: dev-ml/cairo2-0.6.1::ml-overlay failed (compile phase):
 *   (no error message)
 * 
 * Call stack:
 *     ebuild.sh, line 125:  Called src_compile
 *   environment, line 512:  Called jbuilder_src_compile
 *   environment, line 462:  Called die
 * The specific snippet of code:
 *       dune build -p "${PN}" -j $(makeopts_jobs) @install || die
 * 
 * If you need support, post the output of `emerge --info '=dev-ml/cairo2-0.6.1::ml-overlay'`,
 * the complete build log and the output of `emerge -pqv '=dev-ml/cairo2-0.6.1::ml-overlay'`.
 * The complete build log is located at '/var/tmp/portage/dev-ml/cairo2-0.6.1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-ml/cairo2-0.6.1/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-ml/cairo2-0.6.1/work/cairo2-0.6.1'
 * S: '/var/tmp/portage/dev-ml/cairo2-0.6.1/work/cairo2-0.6.1'
```

Installing the package using `opam` requires the following dependencies:

```
$ opam install cairo2
The following actions will be performed:
  - install   conf-cairo        1              [required by cairo2]
  - downgrade dune              2.5.1 to 2.2.0 [required by cairo2]
  - install   dune-configurator 1.11.4         [required by cairo2]
  - recompile menhirSdk         20200211       [uses dune]
  - recompile menhirLib         20200211       [uses dune]
  - recompile integers          0.3.0          [uses dune]
  - install   cairo2            0.6.1
  - recompile menhir            20200211       [uses dune]
  - recompile ctypes            0.17.1         [uses integers]
===== 3 to install | 5 to recompile | 1 to downgrade =====
```
